### PR TITLE
Add simulation info tracking and reporting features

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -10,9 +10,9 @@
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^6.11.0",
+        "async-mutex": "^0.5.0",
         "axios": "^1.10.0",
         "cors": "^2.8.5",
-        "async-mutex": "^0.5.0",
         "dotenv": "^16.4.5",
         "express": "^4.21.2",
         "pg": "^8.16.3",
@@ -798,12 +798,6 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
     "node_modules/async-mutex": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
@@ -812,6 +806,12 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^6.11.0",
+        "async-mutex": "^0.5.0",
         "dotenv": "^16.4.5",
         "express": "^4.21.2",
         "pg": "^8.16.3",
@@ -782,6 +783,15 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
+    },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",

--- a/api/package.json
+++ b/api/package.json
@@ -18,6 +18,7 @@
   "description": "",
   "dependencies": {
     "@prisma/client": "^6.11.0",
+    "async-mutex": "^0.5.0",
     "dotenv": "^16.4.5",
     "express": "^4.21.2",
     "pg": "^8.16.3",

--- a/api/src/domain/shared/value-objects.ts
+++ b/api/src/domain/shared/value-objects.ts
@@ -7,3 +7,35 @@ export interface Weight {
     value: number;
     unit: 'kg'; // Standardizing on kilograms
 }
+
+export type Month =
+  | "January" | "February" | "March" | "April" | "May" | "June"
+  | "July" | "August" | "September" | "October" | "November" | "December";
+
+export type Day = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24 | 25 | 26 | 27 | 28 | 29 | 30 | 31;
+
+export type Chart = {
+  measure: Month,
+  collections: number,
+  purchases: number
+};
+
+export class KeyValueCache<T, V> {
+  private map = new Map<T, V>();
+
+  set(key: T, value: V) {
+    if (this.map.has(key)) {
+        this.map.delete(key);
+    }
+    this.map.set(key, value);
+  }
+
+  get(key: T): V | undefined {
+    return this.map.get(key);
+  }
+
+  getOrderedValues(): V[] {
+    return Array.from(this.map.values());
+  }
+}
+

--- a/api/src/infrastructure/concurrency/index.ts
+++ b/api/src/infrastructure/concurrency/index.ts
@@ -1,0 +1,1 @@
+export * from './mutex.concurreny';

--- a/api/src/infrastructure/concurrency/mutex.concurreny.ts
+++ b/api/src/infrastructure/concurrency/mutex.concurreny.ts
@@ -1,0 +1,28 @@
+import { Mutex } from 'async-mutex';
+
+export class MutexWrapper<T> {
+  private value: T;
+  private mutex = new Mutex();
+
+  constructor(initial: T) {
+    this.value = initial;
+  }
+
+  async read<R>(fn: (val: T) => R | Promise<R>): Promise<R> {
+    const release = await this.mutex.acquire();
+    try {
+      return await fn(this.value);
+    } finally {
+      release();
+    }
+  }
+
+  async update(fn: (prev: T) => T | Promise<T>): Promise<void> {
+    const release = await this.mutex.acquire();
+    try {
+      this.value = await fn(this.value);
+    } finally {
+      release();
+    }
+  }
+}

--- a/api/src/infrastructure/http/controllers/simulation.controllers.ts
+++ b/api/src/infrastructure/http/controllers/simulation.controllers.ts
@@ -1111,6 +1111,8 @@ export class SimulationController {
          */
         router.post('/simulation-info', async (req, res) => {
             try {
+                if (!this.validateSimulationRunning(res)) return;
+                
                 res.status(200).json({
                     message: 'Successfully retrieved simulation information',
                     daysElapsed: calculateDaysElapsed(await this.simulationStartDate.read(async (val) => val) ?? new Date(), new Date()),

--- a/api/src/infrastructure/http/controllers/simulation.controllers.ts
+++ b/api/src/infrastructure/http/controllers/simulation.controllers.ts
@@ -1147,7 +1147,7 @@ export class SimulationController {
          *       500:
          *         description: Error retrieving said information
          */
-        router.post('/simulation-info', async (req, res) => {
+        router.get('/simulation-info', async (req, res) => {
             try {
                 if (!this.validateSimulationRunning(res)) return;
                 

--- a/api/src/infrastructure/http/controllers/simulation.controllers.ts
+++ b/api/src/infrastructure/http/controllers/simulation.controllers.ts
@@ -19,11 +19,21 @@ import { runDailyTasks, SIM_DAY_INTERVAL_MS } from '../../scheduling/daily-tasks
 import { IMarketRepository } from '../../../application/ports/repository.ports';
 import { PgCurrencyRepository } from '../../persistence/postgres/currency.repository';
 import { StopSimulationUseCase } from '../../../application/user-cases/stop-simulation.use-case';
+import { MutexWrapper } from '../../concurrency';
+import { Month, Chart, KeyValueCache } from '../../../domain/shared/value-objects';
+import { getScaledDate, calculateDaysElapsed } from '../../utils';
 
 export class SimulationController {
     private dailyJobInterval: NodeJS.Timeout | null = null;
     private simulationId?: number;
     private advanceSimulationDayUseCase: AdvanceSimulationDayUseCase;
+
+    private simulationStartDate = new MutexWrapper<Date>(new Date());
+    private totalTrades = new MutexWrapper<number>(0);
+    private activities = new MutexWrapper<{ id: string; time: string; description: string; amount: number }[]>([]);
+    private machinery = new MutexWrapper<KeyValueCache<Month, Chart>>(new KeyValueCache<Month, Chart>());
+    private trucks = new MutexWrapper<KeyValueCache<Month, Chart>>(new KeyValueCache<Month, Chart>());
+    private rawMaterials = new MutexWrapper<KeyValueCache<Month, Chart>>(new KeyValueCache<Month, Chart>());
 
     constructor(
         private readonly startSimulationUseCase: StartSimulationUseCase,
@@ -103,6 +113,7 @@ export class SimulationController {
                     }
                 }
 
+                await this.simulationStartDate.update(async () => new Date());
                 res.status(201).json({ message: `Simulation started successfully and daily job started. Generated simulationId: ${simulation.id}`, simulationId });
             } catch (error: any) {
                 console.error(error);
@@ -470,6 +481,29 @@ export class SimulationController {
                     quantity,
                     simulationDate
                 });
+
+                const simulationStartDate = await this.simulationStartDate.read((date) => date);
+                await this.machinery.update((machinery) => {
+                    const dateOfPurchase = getScaledDate(simulationStartDate, new Date());
+                    const machine = machinery.get(dateOfPurchase.month);
+    
+                    machinery.set(
+                        dateOfPurchase.month,
+                        machine ?
+                        {
+                            ...machine,
+                            purchases: machine.purchases + 1
+                        }
+                        :
+                        {
+                            purchases: 1,
+                            collections: 0,
+                            measure: dateOfPurchase.month
+                        }
+                    )
+                    return machinery
+
+                });
                 res.json(result);
             } catch (err: unknown) {
                 res.status(400).json({ error: (err as Error).message });
@@ -535,6 +569,28 @@ export class SimulationController {
                     quantity,
                     simulationDate
                 });
+
+                const simulationStartDate = await this.simulationStartDate.read((date) => date);
+                await this.trucks.update((trucks) => {
+                    const dateOfPurchase = getScaledDate(simulationStartDate, new Date());
+                    const truck = trucks.get(dateOfPurchase.month);
+
+                    trucks.set(
+                        dateOfPurchase.month,
+                        truck ?
+                        {
+                            ...truck,
+                            purchases: truck.purchases + 1
+                        }
+                        :
+                        {
+                            purchases: 1,
+                            collections: 0,
+                            measure: dateOfPurchase.month
+                        }
+                    )
+                    return trucks
+                })
                 res.json(result);
             } catch (err: unknown) {
                 res.status(400).json({ error: (err as Error).message });
@@ -600,6 +656,29 @@ export class SimulationController {
                     weightQuantity,
                     simulationDate
                 });
+
+                const simulationStartDate = await this.simulationStartDate.read((date) => date);
+                await this.rawMaterials.update((rawMaterials) => {
+                    const dateOfPurchase = getScaledDate(simulationStartDate, new Date());
+                    const rawMaterial = rawMaterials.get(dateOfPurchase.month);
+    
+                    rawMaterials.set(
+                        dateOfPurchase.month,
+                        rawMaterial ?
+                        {
+                            ...rawMaterial,
+                            purchases: rawMaterial.purchases + 1
+                        }
+                        :
+                        {
+                            purchases: 1,
+                            collections: 0,
+                            measure: dateOfPurchase.month
+                        }
+                    )
+                    return rawMaterials
+                })
+
                 res.json(result);
             } catch (err: unknown) {
                 res.status(400).json({ error: (err as Error).message });
@@ -669,6 +748,20 @@ export class SimulationController {
                 
                 // If order cannot be fulfilled, return 200 with canFulfill: false
                 // If order can be fulfilled, return 200 with canFulfill: true
+
+                if(result.canFulfill){
+                    await this.totalTrades.update((trades) => trades + 1);
+                    await this.activities.update((activities) => {
+                        const activity = {
+                            id: `${result.orderId}`,
+                            time: new Date().toLocaleTimeString("en-US", { hour12: false, hour: "2-digit", minute: "2-digit" }),
+                            description: `${result.itemName} (${result.quantity} ${result.itemName === 'Raw Material' ? 'kg' : 'units'}) for Đ${result.totalPrice.toFixed(2)}`,
+                            amount: result.totalPrice
+                        };
+                        return [activity, ...activities.slice(0, 9)];
+                    });
+                }
+
                 res.json(result);
             } catch (err: unknown) {
                 if ((err as Error).message.includes('not found')) {
@@ -826,6 +919,33 @@ export class SimulationController {
                 this.simulationId = undefined;
                 
                 res.json({ message: 'Simulation stopped successfully' });
+            } catch (err: unknown) {
+                res.status(500).json({ error: (err as Error).message });
+            }
+        });
+
+        /**
+         * @openapi
+         * /simulation-info:
+         *   get:
+         *     summary: get information on the simulation
+         *     responses:
+         *       200:
+         *         description: an object containing simulation information
+         *       500:
+         *         description: Error retrieving said information
+         */
+        router.post('/simulation-info', async (req, res) => {
+            try {
+                res.status(200).json({
+                    message: 'Successfully retrieved simulation information',
+                    daysElapsed: calculateDaysElapsed(await this.simulationStartDate.read(async (val) => val) ?? new Date(), new Date()),
+                    totalTrades: await this.totalTrades.read(async (val) => val),
+                    activities: await this.activities.read(async (val) => val),
+                    machinery: (await this.machinery.read(async (val) => val)).getOrderedValues(),
+                    trucks: (await this.trucks.read(async (val) => val)).getOrderedValues(),
+                    rawMaterials: (await this.rawMaterials.read(async (val) => val)).getOrderedValues(),
+                });
             } catch (err: unknown) {
                 res.status(500).json({ error: (err as Error).message });
             }

--- a/api/src/infrastructure/utils/index.ts
+++ b/api/src/infrastructure/utils/index.ts
@@ -1,0 +1,32 @@
+import { Day, Month } from "../../domain/shared/value-objects";
+
+const MS_PER_MINUTE = 60 * 1000;
+const SCALED_MINUTES_PER_DAY = 2;
+const AVERAGE_DAYS_PER_MONTH = 30.44;
+const SCALED_MINUTES_PER_MONTH = SCALED_MINUTES_PER_DAY * AVERAGE_DAYS_PER_MONTH; // ≈ 60.88
+
+export function getScaledDate(start: Date, now: Date): { month: Month, day: Day } {
+  const monthNames = [
+    "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December"
+  ];
+
+  const elapsedMs = now.getTime() - start.getTime();
+  const elapsedMinutes = elapsedMs / MS_PER_MINUTE;
+
+  const totalScaledDays = elapsedMinutes / SCALED_MINUTES_PER_DAY;
+
+  const monthIndex = Math.floor(totalScaledDays / AVERAGE_DAYS_PER_MONTH) % 12;
+  const dayOfMonth = Math.floor(totalScaledDays % AVERAGE_DAYS_PER_MONTH) + 1;
+
+  return {
+    month: monthNames[monthIndex] as Month,
+    day: dayOfMonth as Day
+  };
+}
+
+export function calculateDaysElapsed(start: Date, now: Date): number {
+  const elapsedMs = now.getTime() - start.getTime();
+  const elapsedMinutes = elapsedMs / MS_PER_MINUTE;
+  return Math.floor(elapsedMinutes / SCALED_MINUTES_PER_DAY) + 1;
+}

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -3,7 +3,6 @@ import express from "express";
 import cors from 'cors';
 import swaggerUi from 'swagger-ui-express';
 import swaggerJsdoc from 'swagger-jsdoc';
-import RateLimit from 'express-rate-limit';
 import { StartSimulationUseCase } from "./application/user-cases/start-simulation.use-case";
 import { DistributeSalariesUseCase } from "./application/user-cases/distribute-salary-use-case";
 import { SimulationController } from "./infrastructure/http/controllers/simulation.controllers";

--- a/thoh-frontend/src/components/ui/alert-dialog.tsx
+++ b/thoh-frontend/src/components/ui/alert-dialog.tsx
@@ -1,8 +1,8 @@
 import * as React from "react"
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
 
-import { cn } from "@/lib/utils"
-import { buttonVariants } from "@/components/ui/button"
+import { cn } from "../../lib/utils"
+import { buttonVariants } from "./button"
 
 function AlertDialog({
   ...props

--- a/thoh-frontend/src/components/ui/button.tsx
+++ b/thoh-frontend/src/components/ui/button.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
 
-import { cn } from "@/lib/utils"
+import { cn } from "../../lib/utils"
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",

--- a/thoh-frontend/src/components/ui/char-area-stacked.tsx
+++ b/thoh-frontend/src/components/ui/char-area-stacked.tsx
@@ -1,0 +1,77 @@
+import { Area, AreaChart, CartesianGrid, XAxis } from "recharts"
+
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "./chart"
+
+export function ChartAreaStacked(
+  {
+    chartData, 
+    fillColourA = "lightblue", 
+    strokeColourA = "blue",
+    fillColourB = "darkblue", 
+    strokeColourB = "blue"
+  }
+    : 
+  {
+    chartData: {measure: string, collections: number, purchases: number}[], 
+    fillColourA?: string,
+    fillColourB?: string, 
+    strokeColourA?: string,
+    strokeColourB?: string
+  }) {
+    const chartConfig = {
+        collections: {
+            label: "Collections",
+            color: fillColourA,
+        },
+        purchases: {
+            label: "Purchases",
+            color: fillColourB,
+        },
+        } satisfies ChartConfig
+  return (
+    <ChartContainer className="aspect-auto h-full w-full bg-card" config={chartConfig}>
+        <AreaChart
+        accessibilityLayer
+        data={chartData}
+        margin={{
+            left: 12,
+            right: 12,
+        }}
+        >
+        <CartesianGrid vertical={false} />
+        <XAxis
+            dataKey="measure"
+            tickLine={false}
+            axisLine={false}
+            tickMargin={8}
+            tickFormatter={(value) => value.slice(0, 3)}
+        />
+        <ChartTooltip
+            cursor={false}
+            content={<ChartTooltipContent indicator="dot" />}
+        />
+        <Area
+            dataKey="purchases"
+            type="natural"
+            fill={fillColourA}
+            fillOpacity={0.4}
+            stroke={strokeColourA}
+            stackId="a"
+        />
+        <Area
+            dataKey="collections"
+            type="natural"
+            fill={fillColourB}
+            fillOpacity={0.4}
+            stroke={strokeColourB}
+            stackId="a"
+        />
+        </AreaChart>
+    </ChartContainer>
+  )
+}

--- a/thoh-frontend/src/components/ui/chart-area.tsx
+++ b/thoh-frontend/src/components/ui/chart-area.tsx
@@ -7,15 +7,6 @@ import {
   type ChartConfig,
 } from "./chart"
 
-export const description = "A simple area chart"
-
-const chartConfig = {
-  desktop: {
-    label: "Desktop",
-    color: "var(--chart-1)",
-  },
-} satisfies ChartConfig
-
 export function ChartArea(
   {
     chartData, 
@@ -24,13 +15,20 @@ export function ChartArea(
   }
     : 
   {
-    chartData: {month: string, value: number}[], 
+    chartData: {measure: string, value: number}[], 
     fillColour?: string, 
     strokeColour?: string
   }) {
+  const chartConfig = {
+    desktop: {
+      label: "Desktop",
+      color: fillColour,
+    },
+} satisfies ChartConfig
+
   return (
     <ChartContainer 
-    className="aspect-auto h-full w-full"
+    className="aspect-auto h-full w-full bg-card"
     config={chartConfig}>
       <AreaChart
         accessibilityLayer
@@ -42,7 +40,7 @@ export function ChartArea(
       >
         <CartesianGrid vertical={false} />
         <XAxis
-          dataKey="month"
+          dataKey="measure"
           tickLine={false}
           axisLine={false}
           tickMargin={8}

--- a/thoh-frontend/src/components/ui/chart.tsx
+++ b/thoh-frontend/src/components/ui/chart.tsx
@@ -116,14 +116,7 @@ function ChartTooltipContent({
   color,
   nameKey,
   labelKey,
-}: React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
-  React.ComponentProps<"div"> & {
-    hideLabel?: boolean
-    hideIndicator?: boolean
-    indicator?: "line" | "dot" | "dashed"
-    nameKey?: string
-    labelKey?: string
-  }) {
+}: any) {
   const { config } = useChart()
 
   const tooltipLabel = React.useMemo(() => {
@@ -177,7 +170,7 @@ function ChartTooltipContent({
     >
       {!nestLabel ? tooltipLabel : null}
       <div className="grid gap-1.5">
-        {payload.map((item, index) => {
+        {payload.map((item: any, index: any) => {
           const key = `${nameKey || item.name || item.dataKey || "value"}`
           const itemConfig = getPayloadConfigFromPayload(config, item, key)
           const indicatorColor = color || item.payload.fill || item.color
@@ -254,11 +247,7 @@ function ChartLegendContent({
   payload,
   verticalAlign = "bottom",
   nameKey,
-}: React.ComponentProps<"div"> &
-  Pick<RechartsPrimitive.LegendProps, "payload" | "verticalAlign"> & {
-    hideIcon?: boolean
-    nameKey?: string
-  }) {
+}: any) {
   const { config } = useChart()
 
   if (!payload?.length) {
@@ -273,7 +262,7 @@ function ChartLegendContent({
         className
       )}
     >
-      {payload.map((item) => {
+      {payload.map((item: any) => {
         const key = `${nameKey || item.dataKey || "value"}`
         const itemConfig = getPayloadConfigFromPayload(config, item, key)
 

--- a/thoh-frontend/src/components/ui/dropdown-menu.tsx
+++ b/thoh-frontend/src/components/ui/dropdown-menu.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
 import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "../../lib/utils"
 
 function DropdownMenu({
   ...props

--- a/thoh-frontend/src/components/ui/sidebar.tsx
+++ b/thoh-frontend/src/components/ui/sidebar.tsx
@@ -3,25 +3,25 @@ import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
 import { PanelLeftIcon } from "lucide-react"
 
-import { useIsMobile } from "@/hooks/use-mobile"
+import { useIsMobile } from "../../hooks/use-mobile"
 import { cn } from "../../lib/utils"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Separator } from "@/components/ui/separator"
+import { Button } from "./button"
+import { Input } from "./input"
+import { Separator } from "./separator"
 import {
   Sheet,
   SheetContent,
   SheetDescription,
   SheetHeader,
   SheetTitle,
-} from "@/components/ui/sheet"
-import { Skeleton } from "@/components/ui/skeleton"
+} from "./sheet"
+import { Skeleton } from "./skeleton"
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from "@/components/ui/tooltip"
+} from "./tooltip"
 
 const SIDEBAR_COOKIE_NAME = "sidebar_state"
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7

--- a/thoh-frontend/src/lib/constants.ts
+++ b/thoh-frontend/src/lib/constants.ts
@@ -1,6 +1,5 @@
 export const CONSTANTS = {
   API_URL: import.meta.env.VITE_API_URL || "http://localhost:3000",
-  COMMERCIAL_BANK_URL: import.meta.env.VITE_COMMERCIAL_BANK_URL || "http://localhost:3001",
   SIMULATION_SYNC_INTERVAL: 2 * 60 * 1000, // 2 minutes in ms ,
   SIMULATION_SECOND_IN_MS: 12 * 60 * 1000,
 }

--- a/thoh-frontend/src/lib/constants.ts
+++ b/thoh-frontend/src/lib/constants.ts
@@ -1,5 +1,6 @@
 export const CONSTANTS = {
   API_URL: import.meta.env.VITE_API_URL || "http://localhost:3000",
+  COMMERCIAL_BANK_URL: import.meta.env.VITE_COMMERCIAL_BANK_URL || "http://localhost:3001",
   SIMULATION_SYNC_INTERVAL: 2 * 60 * 1000, // 2 minutes in ms ,
   SIMULATION_SECOND_IN_MS: 12 * 60 * 1000,
 }

--- a/thoh-frontend/src/lib/types/shared.types.ts
+++ b/thoh-frontend/src/lib/types/shared.types.ts
@@ -6,3 +6,13 @@ export type BaseApiError = {
   error: string;
   details?: unknown;
 }
+
+export type Month = 'Jan' | 'Feb' | 'Mar' | 'Apr' | 'May' | 'Jun' | 'Jul' | 'Aug' | 'Sep' | 'Oct' | 'Nov' | 'Dec';
+
+export type Day = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24 | 25 | 26 | 27 | 28 | 29 | 30 | 31;
+
+export type Chart = {
+    measure: Month,
+    collections: number,
+    purchases: number
+}

--- a/thoh-frontend/src/lib/types/simulation.types.ts
+++ b/thoh-frontend/src/lib/types/simulation.types.ts
@@ -16,3 +16,12 @@ export type SimulationInfoResponse = BaseApiResponse & {
     trucks: Chart[],
     rawMaterials: Chart[]
 };
+
+export type EntityInfoResponse = {
+    id: number;
+    name: string;
+    balance: string;
+    income: string;
+    expenses: string;
+    loanBalances: string;
+}

--- a/thoh-frontend/src/lib/types/simulation.types.ts
+++ b/thoh-frontend/src/lib/types/simulation.types.ts
@@ -1,5 +1,18 @@
-import type { BaseApiResponse } from "./shared.types";
-
+import type { BaseApiResponse, Chart } from "./shared.types";
 export type StartSimulationResponse = BaseApiResponse & { simulationId: number };
 
 export type StopSimulationResponse = BaseApiResponse;
+
+export type SimulationInfoResponse = BaseApiResponse & {
+    daysElapsed: number,
+    totalTrades: number,
+    activities: {
+        id: string;
+        time: string;
+        description: string;
+        amount: number;
+    }[],
+    machinery: Chart[],
+    trucks: Chart[],
+    rawMaterials: Chart[]
+};

--- a/thoh-frontend/src/pages/EconomicFlowReporting.tsx
+++ b/thoh-frontend/src/pages/EconomicFlowReporting.tsx
@@ -17,7 +17,7 @@ interface Entity {
   id: string
   type: string
   name: string
-  accountValue: number
+  accountValue: string
 }
 
 interface ActivityItem {
@@ -37,13 +37,24 @@ export function EconomicFlowReporting() {
   const [activities, setActivities] = useState<ActivityItem[]>([])
 
   const [entities, setEntities] = useState<Entity[]>([
-    { id: "1", type: "Supplier", name: "Global Materials Ltd", accountValue: 450000 },
-    { id: "2", type: "Logistics", name: "FastTrans Corp", accountValue: 125000 },
-    { id: "3", type: "Retail Bank", name: "RetailBank1", accountValue: 890000 },
-    { id: "4", type: "Commercial Bank", name: "CommercialBank Pro", accountValue: 1200000 },
-    { id: "5", type: "Phone Companies", name: "TechPhone Inc", accountValue: 340000 },
-    { id: "6", type: "Recycler", name: "EcoRecycle Solutions", accountValue: 85000 },
+    { id: "1", type: "Supplier", name: "Global Materials Ltd", accountValue: "450000" },
+    { id: "2", type: "Logistics", name: "FastTrans Corp", accountValue: "125000" },
+    { id: "3", type: "Retail Bank", name: "RetailBank1", accountValue: "890000" },
+    { id: "4", type: "Commercial Bank", name: "CommercialBank Pro", accountValue: "1200000" },
+    { id: "5", type: "Phone Companies", name: "TechPhone Inc", accountValue: "340000" },
+    { id: "6", type: "Recycler", name: "EcoRecycle Solutions", accountValue: "85000" },
   ])
+
+  function getEntityName(type: string): string | undefined {
+    return [
+      "Global Materials Ltd",
+      "FastTrans Corp",
+      "RetailBank1",
+      "CommercialBank Pro",
+      "TechPhone Inc",
+      "EcoRecycle Solutions"
+    ].find((name) => name.toLowerCase().includes(type.toLowerCase()));
+  }
 
   useEffect(() => {
     let interval: NodeJS.Timeout | undefined = undefined;
@@ -57,13 +68,20 @@ export function EconomicFlowReporting() {
           setMachineryChartData(simulationInfo.machinery);
           setTruckChartData(simulationInfo.trucks);
           setRawMaterialsData(simulationInfo.rawMaterials);
-    
-          setEntities((prev) => prev.map((entity) => ({
-            ...entity,
-            accountValue: entity.accountValue + Math.floor(Math.random() * 10000) - 5000
-          })))
         } else{
           throw new Error(simulationInfo.error);
+        }
+
+        const entityInfo = await simulationService.entityInfo();
+        if (!isApiError(entityInfo)) {
+          setEntities(entityInfo.map((entity) => {
+            return {
+              id: entity.id.toString(),
+              type: entity.name,
+              name: entity.name,
+              accountValue: entity.balance
+            }
+          }));
         }
   
       }, 2000) // Update every 2 seconds
@@ -75,10 +93,6 @@ export function EconomicFlowReporting() {
     return () => clearInterval(interval)
   }, [])
 
-  const formatCurrency = (amount: number) => {
-    return `Đ ${amount.toLocaleString()}`
-  }
-
   const getEntityTypeColor = (type: string) => {
     const colors: { [key: string]: string } = {
       "Supplier": "bg-blue-100 text-blue-800",
@@ -89,6 +103,10 @@ export function EconomicFlowReporting() {
       "Recycler": "bg-emerald-100 text-emerald-800",
     }
     return colors[type] || "bg-gray-100 text-gray-800"
+  }
+
+  function formatCurrency(amount: number) {
+    return `Đ ${amount.toLocaleString()}`
   }
 
   return (
@@ -158,8 +176,8 @@ export function EconomicFlowReporting() {
                         <TableCell>
                           <Badge className={getEntityTypeColor(entity.type)}>{entity.type}</Badge>
                         </TableCell>
-                        <TableCell className="font-medium">{entity.name}</TableCell>
-                        <TableCell className="text-right font-mono">{formatCurrency(entity.accountValue)}</TableCell>
+                        <TableCell className="font-medium">{getEntityName(entity.type) ?? "Unknown"}</TableCell>
+                        <TableCell className="text-right font-mono">Đ {entity.accountValue}</TableCell>
                       </TableRow>
                     ))}
                   </TableBody>

--- a/thoh-frontend/src/pages/EconomicFlowReporting.tsx
+++ b/thoh-frontend/src/pages/EconomicFlowReporting.tsx
@@ -72,19 +72,19 @@ export function EconomicFlowReporting() {
           throw new Error(simulationInfo.error);
         }
 
-        const entityInfo = await simulationService.entityInfo();
-        if (!isApiError(entityInfo)) {
-          setEntities(entityInfo.map((entity) => {
-            return {
-              id: entity.id.toString(),
-              type: entity.name,
-              name: entity.name,
-              accountValue: entity.balance
-            }
-          }));
-        }
+        //const entityInfo = await simulationService.entityInfo();
+        //if (!isApiError(entityInfo)) {
+        //  setEntities(entityInfo.map((entity) => {
+        //    return {
+        //      id: entity.id.toString(),
+        //      type: entity.name,
+        //      name: entity.name,
+        //      accountValue: entity.balance
+        //    }
+        //  }));
+        //}
   
-      }, 2000) // Update every 2 seconds
+      }, 5000) // Update every 5 seconds as that eqauls 1 hour in the simulation
     } catch (error) {
       console.error(error);
       clearInterval(interval);

--- a/thoh-frontend/src/pages/PeopleSalaryManager.tsx
+++ b/thoh-frontend/src/pages/PeopleSalaryManager.tsx
@@ -113,10 +113,7 @@ export function PeopleSalaryManager() {
   }
 
   const formatCurrency = (amount: number) => {
-    return new Intl.NumberFormat("en-ZA", {
-      style: "currency",
-      currency: "ZAR",
-    }).format(amount)
+    return `Đ ${amount.toLocaleString()}`
   }
 
   useEffect(() => {

--- a/thoh-frontend/src/pages/PeopleSalaryManager.tsx
+++ b/thoh-frontend/src/pages/PeopleSalaryManager.tsx
@@ -9,6 +9,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from ".
 import type { Person } from "../lib/types/people.types"
 import { isApiError, manageLoading } from "../lib/utils"
 import simulationService from "../services/simulation.service"
+import { Checkbox } from "@radix-ui/react-checkbox"
 
 type PeopleSalaryManagerLoadingState = {
   getPeople: boolean
@@ -122,7 +123,7 @@ export function PeopleSalaryManager() {
                   {!loadingState.getPeople && people.length === 0 ? (
                     <TableRow>
                       <TableCell colSpan={7} className="text-center py-8 text-muted-foreground">
-                        No person found. Click "Add Person" to get started.
+                        No person found.
                       </TableCell>
                     </TableRow>
                   ) : (
@@ -130,7 +131,9 @@ export function PeopleSalaryManager() {
                       <TableRow key={index} className={!person.phoneWorking ? "opacity-60" : ""}>
                         <TableCell className="font-medium">{person.id}</TableCell>
                         <TableCell className="text-center">{person.phone?.model.name || "-"}</TableCell>
-                        <TableCell className="text-center">{person.phone && person.phoneWorking ? "Yes" : person.phoneWorking ? "No" : "-"}</TableCell>
+                        <TableCell className="text-center">
+                          <Checkbox checked={person.phone && person.phoneWorking ? true : false} disabled />
+                        </TableCell>
                         <TableCell className="text-center">{formatCurrency(person.salary)}</TableCell>
                       </TableRow>
                     ))

--- a/thoh-frontend/src/pages/PeopleSalaryManager.tsx
+++ b/thoh-frontend/src/pages/PeopleSalaryManager.tsx
@@ -9,7 +9,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from ".
 import type { Person } from "../lib/types/people.types"
 import { isApiError, manageLoading } from "../lib/utils"
 import simulationService from "../services/simulation.service"
-import { Checkbox } from "@radix-ui/react-checkbox"
+import { Checkbox } from "../components/ui/checkbox"
 
 type PeopleSalaryManagerLoadingState = {
   getPeople: boolean
@@ -113,9 +113,9 @@ export function PeopleSalaryManager() {
                 <TableHeader>
                   <TableRow>
                     <TableHead className="font-semibold">ID</TableHead>
-                    <TableHead className="font-semibold">Phone Model</TableHead>
-                    <TableHead className="font-semibold">Phone Working</TableHead>
-                    <TableHead className="font-semibold">Salary</TableHead>
+                    <TableHead className="font-semibold text-center">Phone Model</TableHead>
+                    <TableHead className="font-semibold text-center">Phone Working</TableHead>
+                    <TableHead className="font-semibold text-center">Salary</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>

--- a/thoh-frontend/src/pages/RawMaterialsEquipment.tsx
+++ b/thoh-frontend/src/pages/RawMaterialsEquipment.tsx
@@ -77,7 +77,7 @@ export function RawMaterialsEquipment() {
     getTrucks: false,
     getRawMaterials: false
   });
-  const [errorState, setErrorState] = useState<RawMaterialsEquipmentErrorState>({
+  const [_, setErrorState] = useState<RawMaterialsEquipmentErrorState>({
     getMachines: undefined,
     getTrucks: undefined,
     getRawMaterials: undefined

--- a/thoh-frontend/src/pages/RawMaterialsEquipment.tsx
+++ b/thoh-frontend/src/pages/RawMaterialsEquipment.tsx
@@ -62,7 +62,7 @@ export function RawMaterialsEquipment() {
   }, [inventory, searchTerm, sortBy, filterCategory])
 
   const formatCurrency = (amount: number) => {
-    return `R ${amount.toLocaleString()}`
+    return `Đ ${amount.toLocaleString()}`
   }
 
   const getCategoryColor = (category: string) => {

--- a/thoh-frontend/src/services/simulation.service.ts
+++ b/thoh-frontend/src/services/simulation.service.ts
@@ -1,7 +1,7 @@
 import { CONSTANTS } from "../lib/constants";
 import type { People } from "../lib/types/people.types";
 import type { BaseApiError } from "../lib/types/shared.types";
-import type { StartSimulationResponse, StopSimulationResponse } from "../lib/types/simulation.types";
+import type { SimulationInfoResponse, StartSimulationResponse, StopSimulationResponse } from "../lib/types/simulation.types";
 import type { EpochTimeResponse, SimulationTime, SimulationTimeResponse } from "../lib/types/time.types";
 
 export type SimulationService = {
@@ -10,6 +10,7 @@ export type SimulationService = {
   getPeople: () => Promise<People | BaseApiError>,
   getEpochTime: () => Promise<Date | BaseApiError>,
   getCurrentSimulationTime: () => Promise<SimulationTime | BaseApiError>,
+  simulationInfo: () => Promise<SimulationInfoResponse | BaseApiError>
 }
 
 const simulationService: SimulationService = {
@@ -70,6 +71,17 @@ const simulationService: SimulationService = {
     if (response.ok) {
       const data = await response.json();
       return data as StopSimulationResponse;
+    } else {
+      const error = await response.json();
+      return error as BaseApiError;
+    }
+  },
+  simulationInfo: async function (): Promise<SimulationInfoResponse | BaseApiError> {
+    const response = await fetch(`${CONSTANTS.API_URL}/simulation-info`);
+
+    if (response.ok) {
+      const data = await response.json();
+      return data as SimulationInfoResponse;
     } else {
       const error = await response.json();
       return error as BaseApiError;

--- a/thoh-frontend/src/services/simulation.service.ts
+++ b/thoh-frontend/src/services/simulation.service.ts
@@ -3,7 +3,7 @@ import type { Machine } from "../lib/types/machines.types";
 import type { People } from "../lib/types/people.types";
 import type { RawMaterial } from "../lib/types/rawMaterials.types";
 import type { BaseApiError } from "../lib/types/shared.types";
-import type { SimulationInfoResponse, StartSimulationResponse, StopSimulationResponse } from "../lib/types/simulation.types";
+import type { EntityInfoResponse, SimulationInfoResponse, StartSimulationResponse, StopSimulationResponse } from "../lib/types/simulation.types";
 import type { EpochTimeResponse, SimulationTime, SimulationTimeResponse } from "../lib/types/time.types";
 import type { Truck } from "../lib/types/truck.types";
 
@@ -17,7 +17,8 @@ export type SimulationService = {
   getMachines: () => Promise<Machine[] | BaseApiError>,
   getTrucks: () => Promise<Truck[] | BaseApiError>,
   getRawMaterials: () => Promise<RawMaterial[] | BaseApiError>,
-  simulationInfo: () => Promise<SimulationInfoResponse | BaseApiError>
+  simulationInfo: () => Promise<SimulationInfoResponse | BaseApiError>,
+  entityInfo: () => Promise<EntityInfoResponse[] | BaseApiError>,
 }
 
 const simulationService: SimulationService = {
@@ -133,6 +134,17 @@ const simulationService: SimulationService = {
     if (response.ok) {
       const data = await response.json();
       return data as SimulationInfoResponse;
+    } else {
+      const error = await response.json();
+      return error as BaseApiError;
+    }
+  },
+  entityInfo: async function (): Promise<EntityInfoResponse[] | BaseApiError> {
+    const response = await fetch(`${CONSTANTS.COMMERCIAL_BANK_URL}/api/dashboard/accounts`);
+
+    if (response.ok) {
+      const data = await response.json();
+      return data as EntityInfoResponse[];
     } else {
       const error = await response.json();
       return error as BaseApiError;


### PR DESCRIPTION
Introduces concurrency-safe state management for simulation statistics (machinery, trucks, raw materials, activities, trades) in the backend using MutexWrapper and KeyValueCache. Adds a new /simulation-info endpoint to provide real-time simulation metrics. Updates frontend types and components to consume and display this data, including new stacked area charts for reporting. Also standardizes currency display to 'Đ' and refactors chart data handling for improved accuracy and clarity.