### PR TITLE
Update API_URL to production server address

### DIFF
--- a/thoh-frontend/src/lib/constants.ts
+++ b/thoh-frontend/src/lib/constants.ts
@@ -1,5 +1,5 @@
 export const CONSTANTS = {
-  API_URL: import.meta.env.VITE_API_URL || "http://localhost:3000",
+  API_URL: "ec2-13-247-96-130.af-south-1.compute.amazonaws.com",
   SIMULATION_SYNC_INTERVAL: 2 * 60 * 1000, // 2 minutes in ms ,
   SIMULATION_SECOND_IN_MS: 12 * 60 * 1000,
 }


### PR DESCRIPTION
Replaces the API_URL constant with the production server address, removing the use of environment variables and the localhost fallback.