### PR TITLE
Add phone purchase and receive use cases to simulation

### DIFF
--- a/api/src/application/user-cases/advance-simulation-day.use-case.ts
+++ b/api/src/application/user-cases/advance-simulation-day.use-case.ts
@@ -12,6 +12,8 @@ import { HandlePeriodicFailuresUseCase } from './handle-periodic-failures.use-ca
 //         this.handlePeriodicFailuresUseCase = new HandlePeriodicFailuresUseCase(marketRepo);
 import { BreakPhonesUseCase } from './break-phones.use-case';
 import { RecyclePhonesUseCase } from './recycle-phones.use-case';
+import { ReceivePhoneUseCase } from './recieve-phone-use-case';
+import { BuyPhoneUseCase } from './buy-phone-use-case';
 
 export class AdvanceSimulationDayUseCase {
   externalsService: ExternalsService;
@@ -20,7 +22,8 @@ export class AdvanceSimulationDayUseCase {
   constructor(
     private readonly simulationRepo: ISimulationRepository,
     private readonly marketRepo: IMarketRepository,
-    private readonly breakPhonesUseCase: BreakPhonesUseCase
+    private readonly breakPhonesUseCase: BreakPhonesUseCase,
+    private readonly buyPhoneUseCase: BuyPhoneUseCase
   ) {
     this.externalsService = new ExternalsService();
     this.recyclePhonesUseCase = new RecyclePhonesUseCase();
@@ -64,6 +67,9 @@ export class AdvanceSimulationDayUseCase {
 
         // Handle periodic failures
         await this.handlePeriodicFailuresUseCase.execute(simulation);
+
+        // Simulate someone randomly buying a phone
+        await this.buyPhoneUseCase.execute();
 
         // Save all changes
         await this.simulationRepo.save(simulation);

--- a/api/src/application/user-cases/buy-phone-use-case.ts
+++ b/api/src/application/user-cases/buy-phone-use-case.ts
@@ -1,0 +1,52 @@
+import { Person } from "../../domain/population/person.entity";
+import { PersonRepository } from "../../infrastructure/persistence/postgres/person.repository";
+
+export class BuyPhoneUseCase {
+  private readonly pearModels = ['ePhone', 'ePhone_plus', 'ePhone_pro_max'];
+  private readonly sumSangModels = ['Cosmos_Z25', 'Cosmos_Z25_ultra', 'Cosmos_Z25_FE'];
+
+  async execute(): Promise<void> {
+    const people = await PersonRepository.getRepo().find({ relations: ['phone', 'phone.model'] });
+
+    for (const person of people) {
+      if (person.phone !== null) continue;
+
+      const usePear = Math.random() % 2 === 0;
+      const model = this.getRandomModel(usePear);
+      const apiUrl = usePear ? process.env.PEAR_PHONE_API_URL : process.env.SUM_SANG_API_URL;
+
+      const success = await this.createOrder(person, model, apiUrl);
+      if (!success) break;
+    }
+  }
+
+  private getRandomModel(usePear: boolean): string {
+    const models = usePear ? this.pearModels : this.sumSangModels;
+    return models[Math.floor(Math.random() * models.length)];
+  }
+
+  private async createOrder(person: Person, model: string, baseUrl?: string): Promise<boolean> {
+    const body = {
+      account_number: person.accountNumber,
+      items: [{ name: model, quantity: 1 }]
+    };
+
+    try {
+      const response = await fetch(`${baseUrl}/orders`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      });
+
+      if (!response.ok) {
+        console.error(`❌ Failed to create order for person ${person.id}: ${response.statusText}`);
+        return false;
+      }
+
+      return true;
+    } catch (error) {
+      console.error(`🚨 Network error for person ${person.id}:`, error);
+      return false;
+    }
+  }
+}

--- a/api/src/application/user-cases/recieve-phone-use-case.ts
+++ b/api/src/application/user-cases/recieve-phone-use-case.ts
@@ -1,0 +1,25 @@
+import { PhoneStatic } from "../../domain/population/phone-static.entity";
+import { PersonRepository } from "../../infrastructure/persistence/postgres/person.repository";
+
+export class ReceivePhoneUseCase {
+  async execute(accountNumber: string, model: PhoneStatic): Promise<void> {
+    const repo = PersonRepository.getRepo();
+    const person = await repo.findOne({
+      where: { accountNumber },
+      relations: ['phone', 'phone.model']
+    });
+
+    if (!person) {
+      console.warn(`Person with account number ${accountNumber} not found.`);
+      return;
+    }
+
+    person.phone = {
+      id: Math.floor(Math.random() * 1_000_000),
+      isBroken: false,
+      model
+    };
+
+    await repo.save(person);
+  }
+}


### PR DESCRIPTION
Introduces BuyPhoneUseCase and ReceivePhoneUseCase for simulating phone purchases and assigning phones to users. Integrates these use cases into AdvanceSimulationDayUseCase and SimulationController, and adds a new /receive-phone API endpoint for assigning phones to people.