### PR TITLE
Add preview host config to Vite setup

### DIFF
--- a/thoh-frontend/vite.config.ts
+++ b/thoh-frontend/vite.config.ts
@@ -11,4 +11,8 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  preview: {
+    host: true,
+    allowedHosts: [".compute.amazonaws.com"],
+  },
 })


### PR DESCRIPTION
Configured Vite preview to allow hosting and restrict allowed hosts to .compute.amazonaws.com domains for improved deployment flexibility.