### PR TITLE
Add dynamic entity data refresh in reporting page

### DIFF
--- a/thoh-frontend/.gitignore
+++ b/thoh-frontend/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.env


### PR DESCRIPTION
Replaces static entity list with dynamic fetching from the API in EconomicFlowReporting. Entities are now updated every 5 seconds along with other simulation data, improving real-time accuracy of displayed information. Also adds .env to .gitignore.