### PR TITLE
Remove IP and SSL client verification from NGINX config

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -166,11 +166,6 @@ jobs:
                   proxy_set_header Connection 'upgrade';
                   proxy_set_header Host \\\$host;
                   proxy_cache_bypass \\\$http_upgrade;
-                  if ($remote_addr != 13.247.96.130) {
-                    if ($ssl_client_verify != SUCCESS) {
-                      return 403;
-                    }
-                  }
               }
           }
           NGINXEOF


### PR DESCRIPTION
Deleted conditional access control in the NGINX configuration that restricted access based on remote IP and SSL client verification. This change may be intended to simplify access or address deployment issues.