### PR TITLE
Use environment variables for SSL certificate paths

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -125,9 +125,9 @@ jobs:
               listen 443 ssl;
               server_name thoh.projects.bbdgrad.com;
 
-              ssl_certificate     /etc/letsencrypt/live/thoh-api.projects.bbdgrad.com/fullchain.pem;
-              ssl_certificate_key /etc/letsencrypt/live/thoh-api.projects.bbdgrad.com/privkey.pem;
-              ssl_client_certificate /etc/nginx/ssl/ca.crt;
+              ssl_certificate     \$SERVER_CERT_PATH;
+              ssl_certificate_key \$SERVER_KEY_PATH;
+              ssl_client_certificate \$CA_CERT_PATH;
 
               ssl_protocols       TLSv1.3;
               ssl_ciphers         HIGH:!aNULL:!MD5;
@@ -151,9 +151,9 @@ jobs:
               listen 443 ssl;
               server_name thoh-api.projects.bbdgrad.com;
 
-              ssl_certificate     /etc/letsencrypt/live/thoh-api.projects.bbdgrad.com/fullchain.pem;
-              ssl_certificate_key /etc/letsencrypt/live/thoh-api.projects.bbdgrad.com/privkey.pem;
-              ssl_client_certificate /etc/nginx/ssl/ca.crt;
+              ssl_certificate     \$SERVER_CERT_PATH;
+              ssl_certificate_key \$SERVER_KEY_PATH;
+              ssl_client_certificate \$CA_CERT_PATH;
 
               ssl_protocols       TLSv1.3;
               ssl_ciphers         HIGH:!aNULL:!MD5;


### PR DESCRIPTION
Replaced hardcoded SSL certificate and key paths in the Nginx configuration with environment variables for improved flexibility and security in the deployment workflow.