### PR TITLE
Handle fetch errors in simulation-info endpoint

### DIFF
--- a/api/src/infrastructure/http/controllers/simulation.controllers.ts
+++ b/api/src/infrastructure/http/controllers/simulation.controllers.ts
@@ -1830,12 +1830,17 @@ export class SimulationController {
         router.get('/simulation-info', async (req, res) => {
             try {
                 if (!this.validateSimulationRunning(res)) return;
+                let response: globalThis.Response| undefined = undefined;
 
-                const response = await fetch("https://commercial-bank-api.projects.bbdgrad.com/simulation/accounts/");
-
-                if (!response.ok) {
-                    throw new Error('Failed to fetch bank account data');
+                try{
+                    response = await fetch("https://commercial-bank-api.projects.bbdgrad.com/simulation/accounts/");
+                    if (!response.ok) {
+                        throw new Error('Failed to fetch bank account data');
+                    }
+                } catch (err: unknown) {
+                    response = undefined;
                 }
+
                 
                 res.status(200).json({
                     message: 'Successfully retrieved simulation information',
@@ -1845,7 +1850,7 @@ export class SimulationController {
                     machinery: (await this.machinery.read(async (val) => val)).getOrderedValues(),
                     trucks: (await this.trucks.read(async (val) => val)).getOrderedValues(),
                     rawMaterials: (await this.rawMaterials.read(async (val) => val)).getOrderedValues(),
-                    entities: response.json()
+                    entities: response ? await response.json() : []
                 });
             } catch (err: unknown) {
                 res.status(500).json({ error: (err as Error).message });


### PR DESCRIPTION
Wrapped the fetch call for bank account data in a try-catch block to handle errors gracefully. If the fetch fails, the entities field returns an empty array instead of causing an unhandled exception.