### PR TITLE
Add RetrieveAccountsUseCase for bank account data

### DIFF
--- a/api/src/application/user-cases/retrieve-accounts-use-case.ts
+++ b/api/src/application/user-cases/retrieve-accounts-use-case.ts
@@ -1,0 +1,37 @@
+import fs from 'fs';
+import path from "node:path";
+import { Agent, fetch, Response } from 'undici';
+
+export class RetrieveAccountsUseCase {
+    constructor() {}
+
+    async execute(): Promise<Response | undefined> {
+        const agent = new Agent({
+            connect: {
+                cert : fs.readFileSync(path.join(__dirname, 'thoh-client.crt')),
+                key : fs.readFileSync(path.join(__dirname, 'thoh-client.key')),
+                ca : fs.readFileSync(path.join(__dirname, 'root-ca.crt')),
+                rejectUnauthorized: false
+            }
+        });
+
+        try{
+            const response = await fetch("https://commercial-bank-api.projects.bbdgrad.com/simulation/accounts/", {
+                method: 'GET',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                dispatcher: agent
+            });
+    
+            if (!response.ok) {
+                throw new Error(`Failed to retrieve accounts: ${response.statusText}`);
+            } else{
+                return response;
+            }
+        } catch (error: unknown) {
+            console.error(`Failed to retrieve accounts:`, (error as Error).message);
+            return undefined;
+        }
+    }
+}

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -33,6 +33,7 @@ import { ReceivePhoneUseCase } from './application/user-cases/recieve-phone-use-
 import { BuyPhoneUseCase } from './application/user-cases/buy-phone-use-case';
 import { AppDataSource } from './domain/shared/data-source';
 import { swaggerOptions } from './swagger-options';
+import { RetrieveAccountsUseCase } from './application/user-cases/retrieve-accounts-use-case';
 
 dotenv.config();
 
@@ -92,6 +93,7 @@ async function initializeApp() {
         const breakPhonesUseCase = new BreakPhonesUseCase(populationRepo);
         const receivePhoneUseCase = new ReceivePhoneUseCase();
         const buyPhoneUseCase = new BuyPhoneUseCase();
+        const retrieveAccountsUseCase = new RetrieveAccountsUseCase();
 
         // Instantiate the Primary Adapter (the API Controller)
         const simulationController = new SimulationController(
@@ -116,7 +118,8 @@ async function initializeApp() {
             //populationRepo,
             breakPhonesUseCase,
             receivePhoneUseCase,
-            buyPhoneUseCase
+            buyPhoneUseCase,
+            retrieveAccountsUseCase
         );
 
         const app = express();


### PR DESCRIPTION
Introduced RetrieveAccountsUseCase to securely fetch bank account data using client certificates. Refactored SimulationController and main.ts to use this new use case for retrieving entities in the /simulation-info endpoint, replacing direct fetch calls.