### PR TITLE
Refactor Chart measure to use WeekDay instead of Month

### DIFF
--- a/api/src/domain/shared/value-objects.ts
+++ b/api/src/domain/shared/value-objects.ts
@@ -14,8 +14,10 @@ export type Month =
 
 export type Day = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24 | 25 | 26 | 27 | 28 | 29 | 30 | 31;
 
+export type WeekDay = "Sunday" | "Monday" | "Tuesday" | "Wednesday" | "Thursday" | "Friday" | "Saturday";
+
 export type Chart = {
-  measure: Month,
+  measure: WeekDay,
   collections: number,
   purchases: number
 };

--- a/api/src/infrastructure/http/controllers/simulation.controllers.ts
+++ b/api/src/infrastructure/http/controllers/simulation.controllers.ts
@@ -26,7 +26,7 @@ import { SIM_DAY_INTERVAL_MS } from '../../scheduling/daily-tasks.job';
 
 import { BuyPhoneUseCase } from '../../../application/user-cases/buy-phone-use-case';
 import { ReceivePhoneUseCase } from '../../../application/user-cases/recieve-phone-use-case';
-import { Chart, KeyValueCache, Month } from '../../../domain/shared/value-objects';
+import { Chart, KeyValueCache, WeekDay } from '../../../domain/shared/value-objects';
 import { MutexWrapper } from '../../concurrency';
 import { calculateDaysElapsed, getScaledDate } from '../../utils';
 
@@ -40,9 +40,9 @@ export class SimulationController {
     private simulationStartDate = new MutexWrapper<Date>(new Date());
     private totalTrades = new MutexWrapper<number>(0);
     private activities = new MutexWrapper<{ id: string; time: string; description: string; amount: number }[]>([]);
-    private machinery = new MutexWrapper<KeyValueCache<Month, Chart>>(new KeyValueCache<Month, Chart>());
-    private trucks = new MutexWrapper<KeyValueCache<Month, Chart>>(new KeyValueCache<Month, Chart>());
-    private rawMaterials = new MutexWrapper<KeyValueCache<Month, Chart>>(new KeyValueCache<Month, Chart>());
+    private machinery = new MutexWrapper<KeyValueCache<WeekDay, Chart>>(new KeyValueCache<WeekDay, Chart>());
+    private trucks = new MutexWrapper<KeyValueCache<WeekDay, Chart>>(new KeyValueCache<WeekDay, Chart>());
+    private rawMaterials = new MutexWrapper<KeyValueCache<WeekDay, Chart>>(new KeyValueCache<WeekDay, Chart>());
 
     constructor(
         private readonly startSimulationUseCase: StartSimulationUseCase,
@@ -907,10 +907,10 @@ export class SimulationController {
                 const simulationStartDate = await this.simulationStartDate.read((date) => date);
                 await this.machinery.update((machinery) => {
                     const dateOfPurchase = getScaledDate(simulationStartDate, new Date());
-                    const machine = machinery.get(dateOfPurchase.month);
+                    const machine = machinery.get(dateOfPurchase.weekday);
     
                     machinery.set(
-                        dateOfPurchase.month,
+                        dateOfPurchase.weekday,
                         machine ?
                         {
                             ...machine,
@@ -920,7 +920,7 @@ export class SimulationController {
                         {
                             purchases: 1,
                             collections: 0,
-                            measure: dateOfPurchase.month
+                            measure: dateOfPurchase.weekday
                         }
                     )
                     return machinery
@@ -1034,10 +1034,10 @@ export class SimulationController {
                 const simulationStartDate = await this.simulationStartDate.read((date) => date);
                 await this.trucks.update((trucks) => {
                     const dateOfPurchase = getScaledDate(simulationStartDate, new Date());
-                    const truck = trucks.get(dateOfPurchase.month);
+                    const truck = trucks.get(dateOfPurchase.weekday);
 
                     trucks.set(
-                        dateOfPurchase.month,
+                        dateOfPurchase.weekday,
                         truck ?
                         {
                             ...truck,
@@ -1047,7 +1047,7 @@ export class SimulationController {
                         {
                             purchases: 1,
                             collections: 0,
-                            measure: dateOfPurchase.month
+                            measure: dateOfPurchase.weekday
                         }
                     )
                     return trucks
@@ -1153,10 +1153,10 @@ export class SimulationController {
                 const simulationStartDate = await this.simulationStartDate.read((date) => date);
                 await this.rawMaterials.update((rawMaterials) => {
                     const dateOfPurchase = getScaledDate(simulationStartDate, new Date());
-                    const rawMaterial = rawMaterials.get(dateOfPurchase.month);
+                    const rawMaterial = rawMaterials.get(dateOfPurchase.weekday);
     
                     rawMaterials.set(
-                        dateOfPurchase.month,
+                        dateOfPurchase.weekday,
                         rawMaterial ?
                         {
                             ...rawMaterial,
@@ -1166,7 +1166,7 @@ export class SimulationController {
                         {
                             purchases: 1,
                             collections: 0,
-                            measure: dateOfPurchase.month
+                            measure: dateOfPurchase.weekday
                         }
                     )
                     return rawMaterials

--- a/api/src/infrastructure/utils/index.ts
+++ b/api/src/infrastructure/utils/index.ts
@@ -1,14 +1,18 @@
-import { Day, Month } from "../../domain/shared/value-objects";
+import { Day, Month, WeekDay } from "../../domain/shared/value-objects";
 
 const MS_PER_MINUTE = 60 * 1000;
 const SCALED_MINUTES_PER_DAY = 2;
 const AVERAGE_DAYS_PER_MONTH = 30.44;
 const SCALED_MINUTES_PER_MONTH = SCALED_MINUTES_PER_DAY * AVERAGE_DAYS_PER_MONTH; // ≈ 60.88
 
-export function getScaledDate(start: Date, now: Date): { month: Month, day: Day } {
+export function getScaledDate(start: Date, now: Date): { month: Month, day: Day, weekday: WeekDay  } {
   const monthNames = [
     "January", "February", "March", "April", "May", "June",
     "July", "August", "September", "October", "November", "December"
+  ];
+
+  const weekdayNames = [
+    "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"
   ];
 
   const elapsedMs = now.getTime() - start.getTime();
@@ -19,9 +23,13 @@ export function getScaledDate(start: Date, now: Date): { month: Month, day: Day 
   const monthIndex = Math.floor(totalScaledDays / AVERAGE_DAYS_PER_MONTH) % 12;
   const dayOfMonth = Math.floor(totalScaledDays % AVERAGE_DAYS_PER_MONTH) + 1;
 
+  const weekdayIndex = Math.floor(totalScaledDays + start.getDay()) % 7;
+  const weekday = weekdayNames[weekdayIndex];
+
   return {
     month: monthNames[monthIndex] as Month,
-    day: dayOfMonth as Day
+    day: dayOfMonth as Day,
+    weekday: weekday as WeekDay
   };
 }
 

--- a/thoh-frontend/src/lib/types/shared.types.ts
+++ b/thoh-frontend/src/lib/types/shared.types.ts
@@ -11,8 +11,10 @@ export type Month = 'Jan' | 'Feb' | 'Mar' | 'Apr' | 'May' | 'Jun' | 'Jul' | 'Aug
 
 export type Day = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24 | 25 | 26 | 27 | 28 | 29 | 30 | 31;
 
+export type WeekDay = "Sunday" | "Monday" | "Tuesday" | "Wednesday" | "Thursday" | "Friday" | "Saturday";
+
 export type Chart = {
-    measure: Month,
+    measure: WeekDay,
     collections: number,
     purchases: number
 }


### PR DESCRIPTION
Changed the Chart type's measure field from Month to WeekDay across shared types, value objects, and simulation controller logic. Updated getScaledDate utility to return weekday information and refactored usages to store and retrieve chart data by weekday instead of month.