### PR TITLE
Remove account retrieval from simulation-info endpoint

### DIFF
--- a/api/src/infrastructure/http/controllers/simulation.controllers.ts
+++ b/api/src/infrastructure/http/controllers/simulation.controllers.ts
@@ -1832,6 +1832,8 @@ export class SimulationController {
         router.get('/simulation-info', async (req, res) => {
             try {
                 if (!this.validateSimulationRunning(res)) return;
+
+                // (await this.retrieveAccountUseCase.execute()) ?? 
                 
                 res.status(200).json({
                     message: 'Successfully retrieved simulation information',
@@ -1841,7 +1843,7 @@ export class SimulationController {
                     machinery: (await this.machinery.read(async (val) => val)).getOrderedValues(),
                     trucks: (await this.trucks.read(async (val) => val)).getOrderedValues(),
                     rawMaterials: (await this.rawMaterials.read(async (val) => val)).getOrderedValues(),
-                    entities: (await this.retrieveAccountUseCase.execute()) ?? [],
+                    entities: [],
                 });
             } catch (err: unknown) {
                 res.status(500).json({ error: (err as Error).message });


### PR DESCRIPTION
The simulation-info endpoint no longer includes entities from retrieveAccountUseCase. Entities are now returned as an empty array, possibly to decouple account data from simulation info or due to changes in requirements.