### PR TITLE
Update account retrieval to return JSON data

### DIFF
--- a/api/src/application/user-cases/retrieve-accounts-use-case.ts
+++ b/api/src/application/user-cases/retrieve-accounts-use-case.ts
@@ -1,11 +1,11 @@
 import fs from 'fs';
 import path from "node:path";
-import { Agent, fetch, Response } from 'undici';
+import { Agent, fetch } from 'undici';
 
 export class RetrieveAccountsUseCase {
     constructor() {}
 
-    async execute(): Promise<Response | undefined> {
+    async execute(): Promise<{success:string, accounts: []} | undefined> {
         const agent = new Agent({
             connect: {
                 cert : fs.readFileSync(path.join(__dirname, 'thoh-client.crt')),
@@ -27,7 +27,7 @@ export class RetrieveAccountsUseCase {
             if (!response.ok) {
                 throw new Error(`Failed to retrieve accounts: ${response.statusText}`);
             } else{
-                return response;
+                return await response.json() as {success:string, accounts: []};
             }
         } catch (error: unknown) {
             console.error(`Failed to retrieve accounts:`, (error as Error).message);

--- a/api/src/infrastructure/http/controllers/simulation.controllers.ts
+++ b/api/src/infrastructure/http/controllers/simulation.controllers.ts
@@ -1832,6 +1832,8 @@ export class SimulationController {
         router.get('/simulation-info', async (req, res) => {
             try {
                 if (!this.validateSimulationRunning(res)) return;
+
+                const response = await this.retrieveAccountUseCase.execute();
                 
                 res.status(200).json({
                     message: 'Successfully retrieved simulation information',
@@ -1841,7 +1843,7 @@ export class SimulationController {
                     machinery: (await this.machinery.read(async (val) => val)).getOrderedValues(),
                     trucks: (await this.trucks.read(async (val) => val)).getOrderedValues(),
                     rawMaterials: (await this.rawMaterials.read(async (val) => val)).getOrderedValues(),
-                    entities: (await this.retrieveAccountUseCase.execute()) ?? [],
+                    entities: response ? response.accounts : [],
                 });
             } catch (err: unknown) {
                 res.status(500).json({ error: (err as Error).message });


### PR DESCRIPTION
Changed RetrieveAccountsUseCase to return parsed JSON instead of Response object. Updated SimulationController to use the new return type and extract accounts for the entities field.